### PR TITLE
AutoMPGRegresion.java variables should not mention Iris

### DIFF
--- a/src/main/java/org/encog/examples/guide/regression/AutoMPGRegression.java
+++ b/src/main/java/org/encog/examples/guide/regression/AutoMPGRegression.java
@@ -57,10 +57,10 @@ public class AutoMPGRegression {
 			tempPath = System.getProperty("java.io.tmpdir");
 		}
 
-		File irisFile = new File(tempPath, "auto-mpg.data");
-		BotUtil.downloadPage(new URL(AutoMPGRegression.DATA_URL), irisFile);
-		System.out.println("Downloading auto-mpg dataset to: " + irisFile);
-		return irisFile;
+		File mpgFile = new File(tempPath, "auto-mpg.data");
+		BotUtil.downloadPage(new URL(AutoMPGRegression.DATA_URL), mpgFile);
+		System.out.println("Downloading auto-mpg dataset to: " + mpgFile);
+		return mpgFile;
 	}
 
 	public void run(String[] args) {
@@ -161,11 +161,11 @@ public class AutoMPGRegression {
 				String correct = csv.get(0);
 				helper.normalizeInputVector(line,input.getData(),false);
 				MLData output = bestMethod.compute(input);
-				String irisChosen = helper.denormalizeOutputVectorToString(output)[0];
+				String predictedMPG = helper.denormalizeOutputVectorToString(output)[0];
 				
 				result.append(Arrays.toString(line));
 				result.append(" -> predicted: ");
-				result.append(irisChosen);
+				result.append(predictedMPG);
 				result.append("(correct: ");
 				result.append(correct);
 				result.append(")");


### PR DESCRIPTION
The AutoMPGRegression example was clearly a cut/paste/modify of the Iris example, but a few variable names did not get modified appropriately.  For what it is worth, I noticed this in the samples in https://s3.amazonaws.com/heatonresearch-books/free/encog-3_3-quickstart.pdf, but I'm not sure how that PDF is generated (I couldn't find it in the code repo). 